### PR TITLE
Add a .run(cb) plugin method to access the router; added docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# IDE Project files
+.idea

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ function someAction(actionContext, payload, done) {
 
 As noted above the location argument to `Router.create` is an isomorphic pivot.
 When on the server side one will want to use `req.url` and on the client side,
-`window.location`. This isomporphic trouble can be solved by abstracting the
-app into a function.
+`Router.HistoryLocation` or another Location implementation. This isomorphic 
+trouble can be solved by abstracting the app into a function.
 
 ```javascript
-function makeApp (url) {
+function makeApp (location) {
   const app = new Fluxible({
     component: require('./mainRoutes.jsx') // your routes component goes here
   })
 
   const router = Router.create({
     routes: app.getComponent(),
-    location: url
+    location: location
   })
 
   app.plug(reactRouter(router))
@@ -60,14 +60,23 @@ function makeApp (url) {
 }
 ```
 
-Now we can pass in the url using the appropriate semantics for the client
+Now we can pass in the location using the appropriate semantics and then run
+the router on the client
 
 ```javascript
 const app = makeApp(Router.HistoryLocation)
+
+app.getPlugin('ReactRouterPlugin').run((Root, state) => {
+  // Render for the client...
+}))
 ```
 
 or the server
 
 ```javascript
 const app = makeApp(req.url)
+
+app.getPlugin('ReactRouterPlugin').run((Root, state) => {
+  // Render for the server...
+}))
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+/**
+ * @class ReactRouterPlugin
+ *
+ * Provides full access to the router on the action context.
+ *
+ * @param {Function} router A router created via `Router.create({routes, location})`.
+ * @returns {Object} The ReactRouterPlugin instance.
+ */
 module.exports = function (router) {
 
   if (!router) {
@@ -13,10 +21,29 @@ module.exports = function (router) {
     plugContext: function plugContext () {
       return {
         /**
-         * Provides full access to the router in the action
+         * Provides full access to the router in the action.
          */
-        plugActionContext: provideRouter,
+        plugActionContext: provideRouter
       }
     },
+
+    /**
+     * Run the router at the appropriate time via the plugin if the original router instance
+     * is no longer available. Example usage:
+     *
+     * ```
+     * // app.js
+     * var router = Router.create({routes, location});
+     * app.plug(ReactRouterPlugin(router));
+     *
+     * // server.js or client.js
+     * app.getPlugin('ReactRouterPlugin').run(function(Root, state) {...});
+     * ```
+     *
+     * @param callback `function(Root, state) {...}`, just like the standard `run` method.
+     */
+    run: function (callback) {
+      router.run(callback);
+    }
   }
-}
+};


### PR DESCRIPTION
Adding a `.run(cb)` method which proxies to the `router.run()` method is the minimal access needed to used the router once the original instance is no longer available. The docs have been updated to reflect this.